### PR TITLE
Add helpers for events

### DIFF
--- a/demo.ts
+++ b/demo.ts
@@ -21,4 +21,10 @@ This is the [G]chorus
 # ✅ Snippets - type "title", "start_of…", "tab" or any other ChordPro directive
 `
 
-createEditor(document.querySelector('#editor')!, { doc })
+createEditor(document.querySelector('#editor')!, { doc }, {
+  onChange: (doc, viewUpdate) => console.log("onChange", doc, viewUpdate),
+  onChangeInterval: 500, // onChange events are debounced by default (300ms)
+  onFocus: viewUpdate => console.log("onFocus", viewUpdate),
+  onBlur: viewUpdate => console.log("onBlur", viewUpdate),
+  onPaste: (event, view) => console.log("onPaste", event, view),
+})

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,32 @@
+import { EditorView, ViewUpdate } from "@codemirror/view"
+import { Extension } from "@codemirror/state"
+
+export interface EventCallbacks {
+  onChange?(doc: string, viewUpdate: ViewUpdate): void
+  onChangeInterval?: number
+  onUpdate?(viewUpdate: ViewUpdate): void
+  onFocus?(viewUpdate: ViewUpdate): void
+  onBlur?(viewUpdate: ViewUpdate): void
+  onPaste?(event: ClipboardEvent, view: EditorView): void
+}
+
+export function eventsToExtensions ({ onChange, onFocus, onBlur, onPaste, onChangeInterval }: EventCallbacks = { onChangeInterval: 300 }): Extension[]  {
+  const debouncedOnChange = onChange && onChangeInterval ? debounce(onChange, onChangeInterval) : onChange
+  return [
+    // https://discuss.codemirror.net/t/codemirror-6-proper-way-to-listen-for-changes/2395/11
+    EditorView.updateListener.of(v => {
+      if (v.docChanged) debouncedOnChange?.(v.state.doc.toString(), v)
+      if (v.focusChanged) v.view.hasFocus ? onFocus?.(v) : onBlur?.(v)
+    }),
+    EditorView.domEventHandlers({ paste: onPaste })
+  ]
+}
+
+export function debounce<T extends Function>(callback: T, wait = 300) {
+  let timeout = 0;
+  let callable = (...args: any) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => callback(...args), wait);
+  };
+  return <T>(<any>callable);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,25 @@
 import { EditorState, EditorStateConfig } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import extensions from "./extensions"
+import { EventCallbacks, eventsToExtensions } from "./events"
 
-export { extensions }
+export type { EventCallbacks }
+export { extensions, eventsToExtensions }
 
-export function createState (state: EditorStateConfig = {}) {
+export function createState(state: EditorStateConfig = {}, events: EventCallbacks = {}) {
+
   return EditorState.create({
-    extensions,
+    extensions: [
+      ...extensions,
+      ...eventsToExtensions(events)
+    ],
     ...state,
   })
 }
 
-export function createEditor (element: HTMLElement, state: EditorStateConfig = {}) {
+export function createEditor (element: HTMLElement, state: EditorStateConfig = {}, events: EventCallbacks = {}) {
   return new EditorView({
     parent: element,
-    state: createState(state),
+    state: createState(state, events),
   })
 }


### PR DESCRIPTION
Since CodeMirror's event handling is a little awkward, this adds a 3rd argument to the `createEditor` constructor that accepts event callbacks.

```ts
import { createEditor } from "@chordbook/editor"

const doc = "This is the initial state"

createEditor(document.querySelector('#editor'), { doc }, {
  onChange: (doc, viewUpdate) => console.log("onChange", doc, viewUpdate),
  onChangeInterval: 500, // onChange events are debounced by default (300ms)
  onFocus: viewUpdate => console.log("onFocus", viewUpdate),
  onBlur: viewUpdate => console.log("onBlur", viewUpdate),
  onPaste: (event, view) => console.log("onPaste", event, view),
})
```